### PR TITLE
[bugfix] Fix LoRA indices in the FC layer

### DIFF
--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -42,6 +42,7 @@ enum LORAParams { loraA, loraB, loraTmp, loraOut };
 FullyConnectedLayer::FullyConnectedLayer() :
   LayerImpl(), fc_props(props::Unit(), props::LoraRank()) {
   weight_idx.fill(std::numeric_limits<unsigned>::max());
+  lora_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
 void FullyConnectedLayer::finalize(InitLayerContext &context) {

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -110,7 +110,7 @@ private:
     fc_props; /**< fc layer properties : unit - number of output neurons,
                  lora_rank : rank of lora (optional) */
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
-  std::array<unsigned int, 2> lora_idx;   /**< indices of the lora weights */
+  std::array<unsigned int, 4> lora_idx;   /**< indices of the lora weights */
 };
 } // namespace nntrainer
 


### PR DESCRIPTION
This PR resolves issues of uninitialized class member variable and incorrect array size for lora_idx.

**Self-evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test:   [X]Passed [ ]Failed [ ]Skipped