### PR TITLE
Patch build system for Android opencl false

### DIFF
--- a/android_opencl_optional.patch
+++ b/android_opencl_optional.patch
@@ -1,0 +1,113 @@
+diff --git a/jni/Android.mk.in b/jni/Android.mk.in
+index 38c3161e..d36de610 100644
+--- a/jni/Android.mk.in
++++ b/jni/Android.mk.in
+@@ -81,12 +81,14 @@ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
+ 
+ include $(BUILD_STATIC_LIBRARY)
+ 
++@MESON_OPENCL_BLOCK_START@
+ include $(CLEAR_VARS)
+ LOCAL_MODULE            := OpenCL
+ LOCAL_SRC_FILES         := @MESON_CL_ROOT@/lib/arm64-v8a/libOpenCL.so
+ LOCAL_EXPORT_C_INCLUDES := @MESON_CL_ROOT@/include
+ 
+ include $(PREBUILT_SHARED_LIBRARY)
++@MESON_OPENCL_BLOCK_END@
+ 
+ include $(CLEAR_VARS)
+ 
+@@ -128,6 +130,7 @@ include $(BUILD_SHARED_LIBRARY)
+ 
+ endif # MESON_HAS_GGML
+ 
++@MESON_CLBLAST_BLOCK_START@
+ include $(CLEAR_VARS)
+ 
+ LOCAL_MODULE        := clblast
+@@ -239,6 +242,7 @@ LOCAL_CXXFLAGS      += -std=c++17 -O3 -fexceptions -DOPENCL_API
+ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
+ 
+ include $(BUILD_STATIC_LIBRARY)
++@MESON_CLBLAST_BLOCK_END@
+ 
+ include $(CLEAR_VARS)
+ 
+@@ -256,8 +260,8 @@ LOCAL_MODULE_TAGS   := optional
+ LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
+ LOCAL_LDFLAGS 	    += "-Wl,-z,max-page-size=16384"
+ 
+-LOCAL_SHARED_LIBRARIES := OpenCL
+-LOCAL_STATIC_LIBRARIES += iniparser openblas ruy clblast
++@MESON_OPENCL_SHARED_LIBS@
++LOCAL_STATIC_LIBRARIES += iniparser openblas ruy @MESON_OPENCL_STATIC_LIBS@
+ 
+ ifeq ($(MESON_HAS_TFLITE), 1)
+   LOCAL_STATIC_LIBRARIES += tensorflow-lite
+diff --git a/jni/meson.build b/jni/meson.build
+index 7b628cfd..923970bd 100644
+--- a/jni/meson.build
++++ b/jni/meson.build
+@@ -41,9 +41,31 @@ if ruy_dep.found()
+   and_conf.set('MESON_RUY_ROOT', ruy_root)
+ endif
+ 
+-if clblast_dep.found()
+-  and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
+-  and_conf.set('MESON_CL_ROOT', opencl_root)
++if get_option('enable-opencl')
++  if clblast_dep.found()
++    and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
++    and_conf.set('MESON_CL_ROOT', opencl_root)
++  endif
++  # Set OpenCL block markers to include the OpenCL sections
++  and_conf.set('MESON_OPENCL_BLOCK_START', '')
++  and_conf.set('MESON_OPENCL_BLOCK_END', '')
++  and_conf.set('MESON_CLBLAST_BLOCK_START', '')
++  and_conf.set('MESON_CLBLAST_BLOCK_END', '')
++  # Set library dependencies
++  and_conf.set('MESON_OPENCL_SHARED_LIBS', 'LOCAL_SHARED_LIBRARIES := OpenCL')
++  and_conf.set('MESON_OPENCL_STATIC_LIBS', 'clblast')
++else
++  # Comment out OpenCL sections when OpenCL is disabled
++  and_conf.set('MESON_OPENCL_BLOCK_START', '# OpenCL disabled - start')
++  and_conf.set('MESON_OPENCL_BLOCK_END', '# OpenCL disabled - end')
++  and_conf.set('MESON_CLBLAST_BLOCK_START', '# CLBlast disabled - start')
++  and_conf.set('MESON_CLBLAST_BLOCK_END', '# CLBlast disabled - end')
++  # No OpenCL libraries needed
++  and_conf.set('MESON_OPENCL_SHARED_LIBS', '# OpenCL disabled - no shared libs')
++  and_conf.set('MESON_OPENCL_STATIC_LIBS', '')
++  # Set dummy paths to avoid undefined variables
++  and_conf.set('MESON_CLBLAST_ROOT', '')
++  and_conf.set('MESON_CL_ROOT', '')
+ endif
+ 
+ if tflite_dep.found()
+diff --git a/meson.build b/meson.build
+index 5d141304..9c5b145a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -172,9 +172,6 @@ if get_option('enable-mmap')
+ endif
+ 
+ if get_option('enable-opencl')
+-  if get_option('platform') == 'android'
+-  endif
+-
+   message ('OpenCL build is now enabled and will function only if an OpenCL-supported GPU is available. Using CLBlast as the OpenCL backend.')
+   extra_defines += '-DENABLE_OPENCL=1'
+   extra_defines += '-DCL_TARGET_OPENCL_VERSION=200'
+@@ -199,6 +196,13 @@ if get_option('enable-opencl')
+     clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
+     clblast_dep = clblast_proj.dependency('clblast')
+   endif
++else
++  # When OpenCL is disabled, set clblast_dep to dummy_dep for Android
++  if get_option('platform') == 'android'
++    clblast_dep = dummy_dep
++    clblast_root = ''
++    opencl_root = ''
++  endif
+ endif
+ 
+ if get_option('opencl-kernel-path') != ''

--- a/android_opencl_optional_patch.md
+++ b/android_opencl_optional_patch.md
@@ -1,0 +1,67 @@
+# Android Build Patch: Making OpenCL Optional
+
+## Problem
+The current build system requires OpenCL to be enabled when building for Android platform (`-Dplatform=android -Denable-opencl=true`). This patch makes OpenCL optional, allowing builds with `-Dplatform=android -Denable-opencl=false`.
+
+## Solution Overview
+The patch modifies three key files to conditionally include OpenCL dependencies based on the `enable-opencl` meson option:
+
+1. **jni/Android.mk.in** - Android NDK build template
+2. **jni/meson.build** - JNI meson configuration
+3. **meson.build** - Main meson build configuration
+
+## Changes Made
+
+### 1. jni/Android.mk.in
+- Wrapped OpenCL and CLBlast library declarations with conditional markers (`@MESON_OPENCL_BLOCK_START@` / `@MESON_OPENCL_BLOCK_END@`)
+- Made OpenCL shared library dependency conditional using `@MESON_OPENCL_SHARED_LIBS@`
+- Made CLBlast static library dependency conditional using `@MESON_OPENCL_STATIC_LIBS@`
+
+### 2. jni/meson.build
+Added conditional logic based on `get_option('enable-opencl')`:
+
+**When OpenCL is enabled:**
+- Sets proper paths for CLBLAST_ROOT and CL_ROOT
+- Sets block markers to empty strings (includes the code)
+- Configures OpenCL shared and static library dependencies
+
+**When OpenCL is disabled:**
+- Sets block markers to comment strings (comments out the code)
+- Sets library dependencies to empty or commented values
+- Sets dummy paths to avoid undefined variable errors
+
+### 3. meson.build
+- Added else block to handle Android platform when OpenCL is disabled
+- Sets clblast_dep to dummy_dep for Android when OpenCL is disabled
+- Initializes empty strings for clblast_root and opencl_root to avoid undefined variables
+
+## Usage
+
+### Building with OpenCL (existing behavior):
+```bash
+meson build -Dplatform=android -Denable-opencl=true
+```
+
+### Building without OpenCL (new capability):
+```bash
+meson build -Dplatform=android -Denable-opencl=false
+```
+
+## Files Modified
+- `jni/Android.mk.in` - Added conditional compilation blocks
+- `jni/meson.build` - Added OpenCL option handling logic
+- `meson.build` - Added fallback for disabled OpenCL on Android
+
+## Testing
+After applying this patch, the build system should:
+1. Successfully configure with `-Dplatform=android -Denable-opencl=false`
+2. Generate Android.mk without OpenCL dependencies when OpenCL is disabled
+3. Build Android libraries without requiring OpenCL libraries
+
+## Patch Application
+To apply the patch:
+```bash
+git apply android_opencl_optional.patch
+```
+
+Or manually apply the changes shown in the patch file.

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -81,12 +81,14 @@ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 include $(BUILD_STATIC_LIBRARY)
 
+@MESON_OPENCL_BLOCK_START@
 include $(CLEAR_VARS)
 LOCAL_MODULE            := OpenCL
 LOCAL_SRC_FILES         := @MESON_CL_ROOT@/lib/arm64-v8a/libOpenCL.so
 LOCAL_EXPORT_C_INCLUDES := @MESON_CL_ROOT@/include
 
 include $(PREBUILT_SHARED_LIBRARY)
+@MESON_OPENCL_BLOCK_END@
 
 include $(CLEAR_VARS)
 
@@ -128,6 +130,7 @@ include $(BUILD_SHARED_LIBRARY)
 
 endif # MESON_HAS_GGML
 
+@MESON_CLBLAST_BLOCK_START@
 include $(CLEAR_VARS)
 
 LOCAL_MODULE        := clblast
@@ -239,6 +242,7 @@ LOCAL_CXXFLAGS      += -std=c++17 -O3 -fexceptions -DOPENCL_API
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
 include $(BUILD_STATIC_LIBRARY)
+@MESON_CLBLAST_BLOCK_END@
 
 include $(CLEAR_VARS)
 
@@ -256,8 +260,8 @@ LOCAL_MODULE_TAGS   := optional
 LOCAL_LDLIBS        := -llog -landroid -fopenmp -static-openmp
 LOCAL_LDFLAGS 	    += "-Wl,-z,max-page-size=16384"
 
-LOCAL_SHARED_LIBRARIES := OpenCL
-LOCAL_STATIC_LIBRARIES += iniparser openblas ruy clblast
+@MESON_OPENCL_SHARED_LIBS@
+LOCAL_STATIC_LIBRARIES += iniparser openblas ruy @MESON_OPENCL_STATIC_LIBS@
 
 ifeq ($(MESON_HAS_TFLITE), 1)
   LOCAL_STATIC_LIBRARIES += tensorflow-lite

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -41,9 +41,31 @@ if ruy_dep.found()
   and_conf.set('MESON_RUY_ROOT', ruy_root)
 endif
 
-if clblast_dep.found()
-  and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
-  and_conf.set('MESON_CL_ROOT', opencl_root)
+if get_option('enable-opencl')
+  if clblast_dep.found()
+    and_conf.set('MESON_CLBLAST_ROOT', clblast_root)
+    and_conf.set('MESON_CL_ROOT', opencl_root)
+  endif
+  # Set OpenCL block markers to include the OpenCL sections
+  and_conf.set('MESON_OPENCL_BLOCK_START', '')
+  and_conf.set('MESON_OPENCL_BLOCK_END', '')
+  and_conf.set('MESON_CLBLAST_BLOCK_START', '')
+  and_conf.set('MESON_CLBLAST_BLOCK_END', '')
+  # Set library dependencies
+  and_conf.set('MESON_OPENCL_SHARED_LIBS', 'LOCAL_SHARED_LIBRARIES := OpenCL')
+  and_conf.set('MESON_OPENCL_STATIC_LIBS', 'clblast')
+else
+  # Comment out OpenCL sections when OpenCL is disabled
+  and_conf.set('MESON_OPENCL_BLOCK_START', '# OpenCL disabled - start')
+  and_conf.set('MESON_OPENCL_BLOCK_END', '# OpenCL disabled - end')
+  and_conf.set('MESON_CLBLAST_BLOCK_START', '# CLBlast disabled - start')
+  and_conf.set('MESON_CLBLAST_BLOCK_END', '# CLBlast disabled - end')
+  # No OpenCL libraries needed
+  and_conf.set('MESON_OPENCL_SHARED_LIBS', '# OpenCL disabled - no shared libs')
+  and_conf.set('MESON_OPENCL_STATIC_LIBS', '')
+  # Set dummy paths to avoid undefined variables
+  and_conf.set('MESON_CLBLAST_ROOT', '')
+  and_conf.set('MESON_CL_ROOT', '')
 endif
 
 if tflite_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -172,9 +172,6 @@ if get_option('enable-mmap')
 endif
 
 if get_option('enable-opencl')
-  if get_option('platform') == 'android'
-  endif
-
   message ('OpenCL build is now enabled and will function only if an OpenCL-supported GPU is available. Using CLBlast as the OpenCL backend.')
   extra_defines += '-DENABLE_OPENCL=1'
   extra_defines += '-DCL_TARGET_OPENCL_VERSION=200'
@@ -198,6 +195,13 @@ if get_option('enable-opencl')
     clblast_options.add_cmake_defines({'CMAKE_POLICY_VERSION_MINIMUM': '3.10'})
     clblast_proj = cmake.subproject('clblast', options: clblast_options, required: true)
     clblast_dep = clblast_proj.dependency('clblast')
+  endif
+else
+  # When OpenCL is disabled, set clblast_dep to dummy_dep for Android
+  if get_option('platform') == 'android'
+    clblast_dep = dummy_dep
+    clblast_root = ''
+    opencl_root = ''
   endif
 endif
 


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR

<details><summary>feat: Make OpenCL optional for Android builds</summary><br />

feat: Make OpenCL optional for Android builds

Previously, building for Android (`-Dplatform=android`) required `enable-opencl=true`. This commit introduces conditional compilation and linking for OpenCL and CLBlast dependencies, allowing the project to be built on Android with `enable-opencl=false`.

This is achieved by:
- Introducing conditional markers in `jni/Android.mk.in` to include/exclude OpenCL and CLBlast related sections.
- Modifying `jni/meson.build` to dynamically set these markers and library dependencies based on the `enable-opencl` option.
- Adjusting `meson.build` to handle the `clblast_dep` and root paths when OpenCL is disabled for Android, preventing build failures.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Your Name <your_email@example.com>

</details>

### Summary

- Enabled building for Android (`-Dplatform=android`) with `enable-opencl=false` by making OpenCL and CLBlast dependencies conditional in the build system.

Signed-off-by: Your Name <your_email@example.com>

---
<a href="https://cursor.com/background-agent?bcId=bc-88a4756a-f85f-4b81-8181-56f7f2965235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88a4756a-f85f-4b81-8181-56f7f2965235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

