### PR TITLE
Update trigonometric calculation with attention scaling

### DIFF
--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -514,7 +514,7 @@ void MHACoreLayer::precompute_freqs(int head_dim, unsigned int seq_len,
 
 #ifdef USE_NEON
     nntrainer::calc_trigonometric_vals_dup(
-      half_, thetas.data(), (*cos)[i].data(), (*sin)[i].data(), i);
+      half_, thetas.data(), (*cos)[i].data(), (*sin)[i].data(), i, attention_scaling);
 #else
     for (unsigned int j = 0; j < half_; ++j) {
       float angle = i * thetas[j];

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -38,9 +38,9 @@ void convert_q4_0x8_shuffle_dispatch(const void *src, uint16_t *d_out,
 }
 
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int alpha) {
+                                 float *sin_, unsigned int from, float attention_scaling) {
   nntrainer::neon::calc_trigonometric_vals_dup(N_half, angle, cos_, sin_,
-                                               alpha);
+                                               from, attention_scaling);
 }
 
 void swiglu(const unsigned int N, float *X, float *Y, float *Z) {

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -542,10 +542,11 @@ void convert_q4_0x8_shuffle_dispatch(const void *src, uint16_t *d_out,
  * @param freqs float* for Vector angle
  * @param cos_ float* for cos_
  * @param sin_ float* for sin_
- * @param alpha scaling factor
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor to apply to cos and sin values
  */
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int alpha = 1.0);
+                                 float *sin_, unsigned int from = 0, float attention_scaling = 1.0f);
 /**
  * @brief swiglu function with neon : X = (Y / (1 + exp( -Y ))) * Z
  *

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
@@ -814,11 +814,30 @@ void transpose_matrix(const unsigned int M, const unsigned int N,
 }
 
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int from) {
+                                 float *sin_, unsigned int from, float attention_scaling) {
   cosine(N_half, angle, cos_, from);
   sine(N_half, angle, sin_, from);
 
+  // Apply attention_scaling to the computed cos and sin values
   unsigned int N = 2 * N_half;
+  
+  // Apply scaling to first half
+  unsigned int j = 0;
+  for (; N_half - j >= 4; j += 4) {
+    float32x4_t cos_vals = vld1q_f32(&cos_[j]);
+    float32x4_t sin_vals = vld1q_f32(&sin_[j]);
+    cos_vals = vmulq_n_f32(cos_vals, attention_scaling);
+    sin_vals = vmulq_n_f32(sin_vals, attention_scaling);
+    vst1q_f32(&cos_[j], cos_vals);
+    vst1q_f32(&sin_[j], sin_vals);
+  }
+  while (j < N_half) {
+    cos_[j] *= attention_scaling;
+    sin_[j] *= attention_scaling;
+    ++j;
+  }
+
+  // Copy scaled values to second half (duplicate)
   unsigned int i = N_half;
   unsigned int i_half = 0;
 

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.h
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.h
@@ -436,10 +436,11 @@ void ele_qmul(int8_t *lhs, int8_t *rhs, int8_t *res, unsigned int data_len,
  * @param angle float* for Vector (radian) angle
  * @param cos_ float* for cos_
  * @param sin_ float* for sin_
- * @param alpha scaling factor
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor to apply to cos and sin values
  */
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int alpha = 1.0);
+                                 float *sin_, unsigned int from = 0, float attention_scaling = 1.0f);
 
 /**
  * @brief swiglu function with neon : X = (Y / (1 + exp( -Y ))) * Z

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -485,11 +485,12 @@ extern void convert_q4_0x8_shuffle_dispatch(const void *src, uint16_t *d_out,
  * @param freqs float* for Vector angle
  * @param cos_ float* for cos_
  * @param sin_ float* for sin_
- * @param alpha scaling factor
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor to apply to cos and sin values
  */
 extern void calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
                                         float *cos_, float *sin_,
-                                        unsigned int alpha = 1.0);
+                                        unsigned int from = 0, float attention_scaling = 1.0f);
 /**
  * @brief swiglu function with neon : X = (Y / (1 + exp( -Y ))) * Z
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -179,8 +179,8 @@ void convert_q4_0x8_shuffle_dispatch(const void *src, uint16_t *d_out,
 }
 
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int alpha) {
-  __fallback_calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, alpha);
+                                 float *sin_, unsigned int from, float attention_scaling) {
+  __fallback_calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, from, attention_scaling);
 }
 
 void swiglu(const unsigned int N, float *X, float *Y, float *Z) {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -427,10 +427,11 @@ void convert_q4_0x8_shuffle_dispatch(const void *src, uint16_t *d_out,
  * @param freqs float* for Vector angle
  * @param cos_ float* for cos_
  * @param sin_ float* for sin_
- * @param alpha scaling factor
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor to apply to cos and sin values
  */
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int alpha = 1.0);
+                                 float *sin_, unsigned int from = 0, float attention_scaling = 1.0f);
 /**
  * @brief swiglu function with neon : X = (Y / (1 + exp( -Y ))) * Z
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -331,7 +331,7 @@ void __fallback_convert_q4_0x8_shuffle_dispatch(const void *src,
 
 void __fallback_calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
                                             float *cos_, float *sin_,
-                                            unsigned int alpha) {
+                                            unsigned int from, float attention_scaling) {
   throw std::runtime_error(
     "Error: No implementation of rotary embedding layer incremental_forwarding "
     "with SIMD acceleration except for NEON!");

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -442,11 +442,12 @@ void __fallback_convert_q4_0x8_shuffle_dispatch(const void *src,
  * @param freqs float* for Vector angle
  * @param cos_ float* for cos_
  * @param sin_ float* for sin_
- * @param alpha scaling factor
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor to apply to cos and sin values
  */
 void __fallback_calc_trigonometric_vals_dup(unsigned int N_half, float *angle,
                                             float *cos_, float *sin_,
-                                            unsigned int alpha = 1.0);
+                                            unsigned int from = 0, float attention_scaling = 1.0f);
 /**
  * @brief swiglu function with neon : X = (Y / (1 + exp( -Y ))) * Z
  *

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -282,8 +282,8 @@ void convert_q4_0x8_shuffle_dispatch(const void *src, uint16_t *d_out,
 }
 
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int alpha) {
-  __fallback_calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, alpha);
+                                 float *sin_, unsigned int from, float attention_scaling) {
+  __fallback_calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, from, attention_scaling);
 }
 
 void swiglu(const unsigned int N, float *X, float *Y, float *Z) {

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -400,10 +400,11 @@ void convert_q4_0x8_shuffle_dispatch(const void *src, uint16_t *d_out,
  * @param freqs float* for Vector angle
  * @param cos_ float* for cos_
  * @param sin_ float* for sin_
- * @param alpha scaling factor
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor to apply to cos and sin values
  */
 void calc_trigonometric_vals_dup(unsigned int N_half, float *angle, float *cos_,
-                                 float *sin_, unsigned int alpha = 1.0);
+                                 float *sin_, unsigned int from = 0, float attention_scaling = 1.0f);
 /**
  * @brief swiglu function with neon : X = (Y / (1 + exp( -Y ))) * Z
  *

--- a/nntrainer/utils/util_simd.cpp
+++ b/nntrainer/utils/util_simd.cpp
@@ -18,8 +18,8 @@ namespace nntrainer {
 
 void calc_trigonometric_vals_dup_util(unsigned int N_half, float *angle,
                                       float *cos_, float *sin_,
-                                      unsigned int alpha) {
-  calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, alpha);
+                                      unsigned int from, float attention_scaling) {
+  calc_trigonometric_vals_dup(N_half, angle, cos_, sin_, from, attention_scaling);
 }
 
 void swiglu_util(const unsigned int N, float *X, float *Y, float *Z) {

--- a/nntrainer/utils/util_simd.h
+++ b/nntrainer/utils/util_simd.h
@@ -27,11 +27,12 @@ namespace nntrainer {
  * @param freqs float* for Vector angle
  * @param cos_ float* for cos_
  * @param sin_ float* for sin_
- * @param alpha scaling factor
+ * @param from starting index for angle calculation
+ * @param attention_scaling scaling factor to apply to cos and sin values
  */
 void calc_trigonometric_vals_dup_util(unsigned int N_half, float *angle,
                                       float *cos_, float *sin_,
-                                      unsigned int alpha = 1.0);
+                                      unsigned int from = 0, float attention_scaling = 1.0f);
 /**
  * @brief swiglu function with neon : X = (Y / (1 + exp( -Y ))) * Z
  *


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR

<details><summary>feat(nntrainer): Apply attention_scaling in NEON trigonometric calculation</summary><br />

The `calc_trigonometric_vals_dup` function in the NEON implementation was not applying the `attention_scaling` factor to the computed cosine and sine values. This commit modifies the function to correctly multiply `cos` and `sin` by `attention_scaling` using NEON intrinsics, aligning its behavior with the non-NEON fallback.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Your Name <your_email@example.com>

</details>

<details><summary>refactor(nntrainer): Propagate attention_scaling parameter across backends</summary><br />

This commit updates function signatures, header declarations, and function calls for `calc_trigonometric_vals_dup` across all CPU backends (ARM, x86, fallback) and the MHA core layer. The `attention_scaling` parameter, introduced in the NEON implementation, is now consistently passed and declared throughout the codebase to ensure correct and unified behavior. The `alpha` parameter was also renamed to `from` for clarity.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Your Name <your_email@example.com>

</details>

### Summary

- The NEON implementation of `calc_trigonometric_vals_dup` now correctly applies `attention_scaling` to cosine and sine values, resolving a discrepancy with the non-NEON fallback.
- The `attention_scaling` parameter has been consistently propagated through function signatures, header declarations, and function calls across all CPU backends and the MHA core layer to ensure API consistency and correct functionality.

Signed-off-by: Your Name <your_email@example.com>

---
<a href="https://cursor.com/background-agent?bcId=bc-4fac06d3-a4f6-4a66-b5ad-5e49791631cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fac06d3-a4f6-4a66-b5ad-5e49791631cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

