### PR TITLE
ci: disable nnstreamer/api/mlagent tests in Tizen CI

### DIFF
--- a/.github/workflows/daily_build_tizen_arm.yml
+++ b/.github/workflows/daily_build_tizen_arm.yml
@@ -52,35 +52,8 @@ jobs:
         path: ~/GBS-ROOT/local/cache
         key: gbs-cache-${{ matrix.gbs_build_arch }}-${{ steps.get-date.outputs.date }}
 
-    - name: get ML API
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/api
-        path: api
-    - name: get ML Agent
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/deviceMLOps.MLAgent
-        path: mlagent
-    - name: get NNStreamer
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/nnstreamer
-        path: _nnstreamer
-    - name: build and test nnstreamer ml-api and ml-agent
-      run: |
-        pushd _nnstreamer
-        echo "::group::Build and run unit-tests for NNStreamer"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
-        pushd api
-        echo "::group::Build and run unit-tests for ML API"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
-        pushd mlagent
-        echo "::group::Build and run unit-tests for ML Agent (deviceMLOps.MLAgent)"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
-        echo "::endgroup::"
-        popd
+    # Disabled: nnstreamer/api/mlagent tests are unstable on Tizen CI
+    # - name: get ML API
+    # - name: get ML Agent
+    # - name: get NNStreamer
+    # - name: build and test nnstreamer ml-api and ml-agent

--- a/.github/workflows/daily_build_tizen_x86_64.yml
+++ b/.github/workflows/daily_build_tizen_x86_64.yml
@@ -44,35 +44,8 @@ jobs:
         path: ~/GBS-ROOT/local/cache
         key: gbs-cache-x86_64-${{ steps.get-date.outputs.date }}
 
-    - name: get ML API
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/api
-        path: api
-    - name: get ML Agent
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/deviceMLOps.MLAgent
-        path: mlagent
-    - name: get NNStreamer
-      uses: actions/checkout@v4
-      with:
-        repository: nnstreamer/nnstreamer
-        path: _nnstreamer
-    - name: build and test nnstreamer ml-api and ml-agent
-      run: |
-        pushd _nnstreamer
-        echo "::group::Build and run unit-tests for NNStreamer"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A x86_64 --define "unit_test 1"
-        echo "::endgroup::"
-        popd
-        pushd api
-        echo "::group::Build and run unit-tests for ML API"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A x86_64 --define "unit_test 1"
-        echo "::endgroup::"
-        popd
-        pushd mlagent
-        echo "::group::Build and run unit-tests for ML Agent (deviceMLOps.MLAgent)"
-        gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A x86_64 --define "unit_test 1"
-        echo "::endgroup::"
-        popd
+    # Disabled: nnstreamer/api/mlagent tests are unstable on Tizen CI
+    # - name: get ML API
+    # - name: get ML Agent
+    # - name: get NNStreamer
+    # - name: build and test nnstreamer ml-api and ml-agent


### PR DESCRIPTION
## Summary
- Disable unstable nnstreamer, ML API, and ML Agent build/test steps in Tizen CI
- Comment out external repo (nnstreamer, api, mlagent) checkout and GBS build/test steps in both `daily_build_tizen_x86_64.yml` and `daily_build_tizen_arm.yml`
- nntrainer's own build and tests remain unchanged

## Test plan
- [ ] Verify Tizen x86_64 CI passes without nnstreamer/api/mlagent test steps
- [ ] Verify Tizen ARM CI passes without nnstreamer/api/mlagent test steps

https://claude.ai/code/session_01MxhB8DQGGQeYRgCnU3Axvk